### PR TITLE
feat: Replace Google Places API with Foursquare API

### DIFF
--- a/controllers/index.ts
+++ b/controllers/index.ts
@@ -4,7 +4,7 @@ import { IFood } from "../models/types";
 import { mapFiles } from "../middlewares/file";
 import dotenv from 'dotenv'
 import axios from "axios";
-import { getNearbyRestaurants, ILocation } from "../utils/google-places";
+import { getNearbyRestaurants, ILocation } from "../utils/location";
 
 dotenv.config()
 

--- a/utils/location.ts
+++ b/utils/location.ts
@@ -4,8 +4,8 @@ import redis from './redis';
 
 dotenv.config();
 
-const GOOGLE_PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
-const PLACES_API_URL = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
+const FOURSQUARE_API_KEY = process.env.FOURSQUARE_API_KEY;
+const FOURSQUARE_API_URL = 'https://api.foursquare.com/v3/places/search';
 const CACHE_EXPIRATION = 86400; // 24 hours in seconds
 
 export interface ILocation {
@@ -16,14 +16,14 @@ export interface ILocation {
 }
 
 export const getNearbyRestaurants = async (dish: string, lat: number, lon: number): Promise<ILocation[]> => {
-    if (!GOOGLE_PLACES_API_KEY) {
-        console.warn('Google Places API key is not configured. Skipping location search.');
+    if (!FOURSQUARE_API_KEY) {
+        console.warn('Foursquare API key is not configured. Skipping location search.');
         return [];
     }
 
     if (!redis) {
         console.warn('Redis client not available, skipping cache.');
-        return fetchFromGooglePlaces(dish, lat, lon);
+        return fetchFromFoursquare(dish, lat, lon);
     }
 
     const cacheKey = `restaurants:${dish}:${lat}:${lon}`;
@@ -38,7 +38,7 @@ export const getNearbyRestaurants = async (dish: string, lat: number, lon: numbe
         console.error('Redis error:', error);
     }
 
-    const locations = await fetchFromGooglePlaces(dish, lat, lon);
+    const locations = await fetchFromFoursquare(dish, lat, lon);
 
     try {
         await redis.set(cacheKey, JSON.stringify(locations), 'EX', CACHE_EXPIRATION);
@@ -49,16 +49,51 @@ export const getNearbyRestaurants = async (dish: string, lat: number, lon: numbe
     return locations;
 };
 
+const fetchFromFoursquare = async (dish: string, lat: number, lon: number): Promise<ILocation[]> => {
+    try {
+        console.log('Fetching from Foursquare API');
+        const response = await axios.get(FOURSQUARE_API_URL, {
+            headers: {
+                Authorization: FOURSQUARE_API_KEY!,
+            },
+            params: {
+                ll: `${lat},${lon}`,
+                query: `${dish} restaurant`,
+                radius: 5000,
+                categories: '13000', // Dining and Drinking
+                fields: 'fsq_id,name,location,rating,link',
+                limit: 20,
+            },
+        });
+
+        const { results } = response.data;
+
+        const locations: ILocation[] = results.map((place: any) => ({
+            name: place.name || 'No name provided',
+            address: place.location?.formatted_address || 'No address provided',
+            rating: place.rating ? place.rating / 2 : 0, // Foursquare rating is out of 10, converting to 5-star scale
+            url: place.link ? `https://foursquare.com${place.link}` : 'No URL provided',
+        }));
+
+        return locations;
+    } catch (error) {
+        console.error('Error fetching from Foursquare API:', error);
+        return [];
+    }
+};
+
+
+/*
 const fetchFromGooglePlaces = async (dish: string, lat: number, lon: number): Promise<ILocation[]> => {
     try {
         console.log('Fetching from Google Places API');
-        const response = await axios.get(PLACES_API_URL, {
+        const response = await axios.get('https://maps.googleapis.com/maps/api/place/nearbysearch/json', {
             params: {
                 location: `${lat},${lon}`,
                 radius: 5000, // 5km radius
                 keyword: `${dish} restaurant`,
                 type: 'restaurant',
-                key: GOOGLE_PLACES_API_KEY,
+                key: process.env.GOOGLE_PLACES_API_KEY,
             },
         });
 
@@ -77,3 +112,4 @@ const fetchFromGooglePlaces = async (dish: string, lat: number, lon: number): Pr
         return [];
     }
 };
+*/


### PR DESCRIPTION
This commit refactors the location service to use the Foursquare Places API instead of the Google Places API for fetching nearby restaurant data. This change was made to address the user's issues with Google Cloud Billing.

Key changes include:
- The location service file has been renamed to `utils/location.ts` to be more generic.
- A new function, `fetchFromFoursquare`, has been implemented to handle API calls to the Foursquare "Place Search" endpoint.
- The old `fetchFromGooglePlaces` function has been commented out for reference.
- The `.env` file has been updated to use a `FOURSQUARE_API_KEY` instead of a Google Places key.